### PR TITLE
fix broken download links

### DIFF
--- a/.github/workflows/php-release.yml
+++ b/.github/workflows/php-release.yml
@@ -47,7 +47,7 @@ jobs:
           while read -r filepath; do
             filename=$(basename "$filepath")
             echo "Downloading: $filename"
-            curl -L -o "downloads/$filename" "https://dl.static-php.dev/$filepath"
+            curl -L -o "downloads/$filename" "https://dl.static-php.dev$filepath"
 
             # Extract architecture and file extension for both .tar.gz and .zip files
             if [[ "$filename" =~ php-${VERSION}-cli-(.+)\.tar\.gz$ ]]; then


### PR DESCRIPTION
a double slash is created when composing the download links for each binary, eg: `https://dl.static-php.dev//static-php-cli/bulk/php-8.5.5-cli-macos-aarch64.tar.gz`. Previously the server will rectify and redirect to the correct URL but not anymore, causing the curl command to download a 404 page instead. This PR fixes it by removing the necessary slash.
